### PR TITLE
Fix comment typo in hide-labwc-cursor

### DIFF
--- a/scripts/hide-labwc-cursor.sh
+++ b/scripts/hide-labwc-cursor.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Hides cursor in labwc by moving left pointer cursor.
-# Mouse movemoent is still being track. If the pointer is moved over area
-# with different pointer icon, the pointer will show. 
+# Mouse movement is still being tracked. If the pointer is moved over area
+# with different pointer icon, the pointer will show.
 
 # Renames the left pointer icon to left_ptr.backup so system does not load it. 
 sudo mv /usr/share/icons/Adwaita/cursors/left_ptr /usr/share/icons/Adwaita/cursors/left_ptr.backup


### PR DESCRIPTION
## Summary
- correct typo in `hide-labwc-cursor.sh` comment

## Testing
- `bash -n scripts/hide-labwc-cursor.sh`


------
https://chatgpt.com/codex/tasks/task_e_6847baefaadc8330b97f414c82b18a0d