### PR TITLE
Fix hotspot exit command

### DIFF
--- a/scripts/router-show-pi.sh
+++ b/scripts/router-show-pi.sh
@@ -36,7 +36,7 @@ start_hotspot() {
         echo "Disconnecting from $current_conn"
         echo "Please connect to show-pi wifi"
         sudo nmcli connection up showpi-hotspot
-        exit=0
+        exit 0
     else
         echo "Hotspot connection already exists."
     fi


### PR DESCRIPTION
## Summary
- fix a typo in `router-show-pi.sh` so the hotspot function exits correctly

## Testing
- `bash -n scripts/router-show-pi.sh`


------
https://chatgpt.com/codex/tasks/task_e_6847bbb97fb483309073841f22f2e132